### PR TITLE
Fix Supabase CI and deployment migration history

### DIFF
--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2"
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2"
   }
 }

--- a/supabase/migrations/20260524124724_remote_schema.sql
+++ b/supabase/migrations/20260524124724_remote_schema.sql
@@ -1,0 +1,5 @@
+-- Intentionally left blank.
+-- This placeholder preserves migration history for environments where
+-- version 20260524124724 was already recorded remotely.
+-- The original generated remote schema dump was removed because it was not
+-- a safe incremental migration and broke foreign-key dependent deploys.


### PR DESCRIPTION
## Summary

This PR fixes the recent CI/CD failures affecting Supabase validation and deployment.

## Changes

- remove the unsafe generated remote schema migration logic that was breaking foreign-key dependent deploys
- restore migration history compatibility with a safe placeholder for version `20260524124724`
- switch Supabase Edge Functions imports from `esm.sh` to `npm:@supabase/supabase-js@2` to avoid flaky remote import failures during `deno check`

## Why

CI was failing for two separate reasons:

1. The migration `20260524124724_remote_schema.sql` had introduced unsafe schema rewrite behavior and caused deploy errors around `users_auth_uid_key`.
2. Edge Function type-checking was failing because `esm.sh` returned a `522` during GitHub Actions.

## Expected result

- `supabase db reset` passes in CI
- `deno check` for Edge Functions becomes stable
- `supabase db push --dry-run` no longer fails because remote migration history and local files are aligned