### PR TITLE
Remove static catalog recommendations and align activity flows with real home data

### DIFF
--- a/app/(tabs)/Activities.tsx
+++ b/app/(tabs)/Activities.tsx
@@ -30,13 +30,10 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import {
   Activity,
-  CONTENTS,
   Scenario,
 } from '@/constants/data';
 import { resolveCatalogImage } from '@/constants/data/catalogAssets';
 import {
-  fetchActivityTemplates,
-  fetchScenarioTemplates,
   fetchUserScenarios,
   mapUserActivity,
 } from '@/utils/catalogTemplates';
@@ -69,6 +66,7 @@ const UnifiedActivitiesScreen = () => {
   const [myActivities, setMyActivities] = useState<Activity[]>([]);
   const [activityTemplates, setActivityTemplates] = useState<Activity[]>([]);
   const [scenarioTemplates, setScenarioTemplates] = useState<Scenario[]>([]);
+  const [contentDurations, setContentDurations] = useState<Record<string, string>>({});
   const [page, setPage] = useState(0);
   const [hasMore, setHasMore] = useState(true);
   const [isAiModalVisible, setIsAiModalVisible] = useState(false);
@@ -93,7 +91,6 @@ const UnifiedActivitiesScreen = () => {
   const isLoadingRef = useRef(false);
   const lastAutoRecommendationRequestKeyRef = useRef<string | null>(null);
   const PAGE_SIZE = 10;
-
   // Debounce search query
   useEffect(() => {
     const handler = setTimeout(() => {
@@ -104,17 +101,28 @@ const UnifiedActivitiesScreen = () => {
 
   const loadTemplates = useCallback(async () => {
     try {
-      const [activities, scenarios, userScenarios] = await Promise.all([
-        fetchActivityTemplates(),
-        fetchScenarioTemplates(),
-        fetchUserScenarios().catch(() => []),
-      ]);
-      setActivityTemplates(activities);
-      setScenarioTemplates([...userScenarios, ...scenarios]);
+      const userScenarios = await fetchUserScenarios().catch(() => []);
+      setActivityTemplates([]);
+      setScenarioTemplates(userScenarios);
     } catch (error) {
       logger.error('Failed to load activity/scenario templates:', error);
       setActivityTemplates([]);
       setScenarioTemplates([]);
+    }
+  }, []);
+
+  const loadContentDurations = useCallback(async () => {
+    try {
+      const { data, error } = await supabase.from('contents').select('id, duration');
+      if (error) throw error;
+
+      const nextDurations = Object.fromEntries(
+        (data ?? []).map((item) => [String(item.id), String(item.duration ?? '')]),
+      );
+      setContentDurations(nextDurations);
+    } catch (error) {
+      logger.warn('Failed to load content durations:', error);
+      setContentDurations({});
     }
   }, []);
 
@@ -178,8 +186,9 @@ const UnifiedActivitiesScreen = () => {
   useFocusEffect(
     useCallback(() => {
       loadTemplates();
+      loadContentDurations();
       loadActivities();
-    }, [loadActivities, loadTemplates])
+    }, [loadActivities, loadContentDurations, loadTemplates])
   );
 
   useFocusEffect(
@@ -277,8 +286,8 @@ const UnifiedActivitiesScreen = () => {
 
   const getActivityTime = (activity: Activity) => {
     const cId = activity.content_id || activity.contentId;
-    if (cId && CONTENTS[cId]) {
-      return CONTENTS[cId].duration;
+    if (cId) {
+      return contentDurations[String(cId)];
     }
     return undefined;
   };

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -12,10 +12,11 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { UnifiedCard } from '@/components/activitiesScenarios/UnifiedCard';
 import { CarouselSection } from '../../components/activitiesScenarios/CarouselSection';
+import { CustomAlert } from '@/components/CustomAlert';
 import { HomeHeader } from '../../components/Homepage/HomeHeader';
 import { StateWidget } from '../../components/Homepage/StateWidget';
 
-import { CONTENTS, Activity } from '@/constants/data';
+import { Activity } from '@/constants/data';
 import { resolveCatalogImage } from '@/constants/data/catalogAssets';
 import { useBiometrics } from '@/context/BiometricsContext';
 import {
@@ -29,10 +30,7 @@ import { isAiAutoInvocationEnabled } from '@/utils/aiConfig';
 import { logger } from '@/utils/logger';
 import { getDynamicRecommendations } from '@/utils/recommendationEngine';
 import { getSessionUser, supabase } from '@/utils/supabase';
-import {
-  fetchActivityTemplates,
-  mapUserActivity,
-} from '@/utils/catalogTemplates';
+import { mapUserActivity } from '@/utils/catalogTemplates';
 
 type ShortcutRow = {
   id: number;
@@ -56,8 +54,7 @@ type CarouselActivity = Activity & {
 };
 
 const getContentDuration = (contentId: string | undefined) => {
-  if (!contentId) return undefined;
-  return CONTENTS[contentId]?.duration;
+  return contentId;
 };
 
 const getActivityRoomLabel = (item: Activity) => item.room || item.room_id;
@@ -77,6 +74,9 @@ const parseHobbies = (value: unknown) => {
   );
 };
 
+const isCatalogTemplateActivity = (item: Activity) =>
+  String(item.id).startsWith('template:');
+
 export default function Index() {
   const [fontsLoaded] = useFonts({
     Nunito_700Bold,
@@ -88,12 +88,23 @@ export default function Index() {
   const [userName, setUserName] = useState('...');
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [myActivities, setMyActivities] = useState<Activity[]>([]);
-  const [activityTemplates, setActivityTemplates] = useState<Activity[]>([]);
+  const [contentDurations, setContentDurations] = useState<Record<string, string>>({});
   const [shortcutRows, setShortcutRows] = useState<ShortcutRow[]>([]);
   const [userHobbies, setUserHobbies] = useState<string[]>([]);
   const [aiHomeIdeas, setAiHomeIdeas] = useState<AiActivityIdea[]>([]);
   const [isLoadingAiHomeIdeas, setIsLoadingAiHomeIdeas] = useState(false);
   const [isSavingAiHomeIdeaId, setIsSavingAiHomeIdeaId] = useState<string | null>(null);
+  const [aiAlert, setAiAlert] = useState<{
+    visible: boolean;
+    title: string;
+    message: string;
+    type: 'error' | 'info';
+  }>({
+    visible: false,
+    title: '',
+    message: '',
+    type: 'info',
+  });
   const [isEditingShortcuts, setIsEditingShortcuts] = useState(false);
   const [isSavingShortcutOrder, setIsSavingShortcutOrder] = useState(false);
   const [draggingShortcutId, setDraggingShortcutId] = useState<number | null>(null);
@@ -233,16 +244,22 @@ export default function Index() {
 
         setUserHobbies(parseHobbies(userResult.data?.hobbies));
       };
-      const loadTemplates = async () => {
+      const loadContentDurations = async () => {
         try {
-          const activities = await fetchActivityTemplates();
-          setActivityTemplates(activities);
+          const { data, error } = await supabase.from('contents').select('id, duration');
+          if (error) throw error;
+
+          setContentDurations(
+            Object.fromEntries(
+              (data ?? []).map((item) => [String(item.id), String(item.duration ?? '')]),
+            ),
+          );
         } catch (error) {
-          console.error('Failed to load home catalog templates:', error);
-          setActivityTemplates([]);
+          console.error('Failed to load content durations:', error);
+          setContentDurations({});
         }
       };
-      loadTemplates();
+      loadContentDurations();
       loadActivities();
     }, [])
   );
@@ -319,10 +336,15 @@ export default function Index() {
           isNew: 'true',
         },
       });
-    } catch (error) {
-      if (!(await isAiRateLimitError(error))) {
-        console.error('Failed to save AI home recommendation:', error);
-      }
+    } catch (error: unknown) {
+      logger.warn('Failed to save AI home recommendation:', error);
+      const message = await getNidushAiErrorMessage(error);
+      setAiAlert({
+        visible: true,
+        title: 'Could not save activity',
+        message,
+        type: await isAiRateLimitError(error) ? 'info' : 'error',
+      });
     } finally {
       setIsSavingAiHomeIdeaId(null);
     }
@@ -342,7 +364,8 @@ export default function Index() {
     }
 
     const formatActivityForCarousel = (item: Activity): CarouselActivity => {
-      const duration = getContentDuration(item.content_id || item.contentId);
+      const contentId = item.content_id || item.contentId;
+      const duration = contentId ? contentDurations[String(contentId)] : undefined;
 
       return {
         ...item,
@@ -351,23 +374,20 @@ export default function Index() {
       };
     };
 
-    // 1. Aplicar filtro de Hobbies se o utilizador tiver algum selecionado
-    const appActivities = activityTemplates.filter((item) => {
-      // Se o user tiver hobbies, filtramos; se não tiver, mostramos todos
+    const personalizedActivities = myActivities.filter((item) => {
+      if (isCatalogTemplateActivity(item)) return false;
       if (userHobbies.length > 0) {
-        // item.type (meditation, cooking, workout, audiobooks)
-        return userHobbies.some(h => h.toLowerCase() === item.type?.toLowerCase());
+        return userHobbies.some((h) => h.toLowerCase() === item.type?.toLowerCase());
       }
-      
       return true;
     });
 
     const sortedList = getDynamicRecommendations(
-      appActivities,
+      personalizedActivities,
       currentState,
     ) as Activity[];
 
-    const combinedList = [...myActivities, ...sortedList];
+    const combinedList = [...sortedList];
     const seenIds = new Set<string>();
 
     return combinedList
@@ -379,7 +399,7 @@ export default function Index() {
       })
       .slice(0, 8)
       .map(formatActivityForCarousel);
-  }, [activityTemplates, aiHomeIdeas, currentState, isSavingAiHomeIdeaId, myActivities, saveHomeAiIdea, userHobbies]);
+  }, [aiHomeIdeas, contentDurations, currentState, isSavingAiHomeIdeaId, myActivities, saveHomeAiIdea, userHobbies]);
 
 
   const dynamicTitle = useMemo(() => {
@@ -409,8 +429,8 @@ export default function Index() {
           (activityShortcutMap.get(String(b.id))?.displayorder ?? 0),
       )
       .map((item) => {
-      // Tentar encontrar a duração no CONTENTS
-      const duration = getContentDuration(item.content_id || item.contentId);
+      const contentId = item.content_id || item.contentId;
+      const duration = contentId ? contentDurations[String(contentId)] : undefined;
 
       return {
         shortcutId: activityShortcutMap.get(String(item.id))!.shortcutId,
@@ -426,7 +446,7 @@ export default function Index() {
     });
 
     return favActivities;
-  }, [myActivities, shortcutRows]);
+  }, [contentDurations, myActivities, shortcutRows]);
 
   const saveShortcutOrder = async (orderedRows: ShortcutRow[]) => {
     setIsSavingShortcutOrder(true);
@@ -720,6 +740,19 @@ export default function Index() {
           )}
         </View>
       </ScrollView>
+      <CustomAlert
+        visible={aiAlert.visible}
+        title={aiAlert.title}
+        message={aiAlert.message}
+        type={aiAlert.type}
+        confirmText="OK"
+        onClose={() =>
+          setAiAlert((current) => ({
+            ...current,
+            visible: false,
+          }))
+        }
+      />
     </SafeAreaView>
   );
 }

--- a/app/ActiveSession.tsx
+++ b/app/ActiveSession.tsx
@@ -31,7 +31,6 @@ import { useSpotify } from '@/context/SpotifyContext';
 
 import {
   Activity,
-  CONTENTS,
   Scenario,
   ScenarioDeviceState,
 } from '@/constants/data';
@@ -426,7 +425,6 @@ export default function ActiveSession() {
       let connectedTvName: string | undefined = undefined;
 
       const contentId = getContentId(foundItem);
-      const localContent = contentId ? CONTENTS[String(contentId)] : null;
 
       if (foundItem && contentId) {
         const { data: contentRows } = await supabase
@@ -439,20 +437,10 @@ export default function ActiveSession() {
           contentRows && contentRows.length > 0 ? contentRows[0] : null;
 
         if (contentData) {
-          playlistName =
-            contentData.title || localContent?.title || playlistName;
-          if (contentData.type === 'video' || localContent?.type === 'video') {
+          playlistName = contentData.title || playlistName;
+          if (contentData.type === 'video') {
             contentType = 'video';
-            videoUrl =
-              localContent?.videoUrl || contentData.video_url || undefined;
-          }
-        } else {
-          if (localContent) {
-            playlistName = localContent.title;
-            if (localContent.type === 'video') {
-              contentType = 'video';
-              videoUrl = localContent.videoUrl;
-            }
+            videoUrl = contentData.video_url || undefined;
           }
         }
       }
@@ -502,7 +490,7 @@ export default function ActiveSession() {
       }
 
       const rawInstructions = parseArrayValue<FormattedInstruction | string>(
-        contentData?.instructions || localContent?.instructions || [],
+        contentData?.instructions || [],
       );
 
       const formattedInstructions: FormattedInstruction[] = rawInstructions
@@ -550,15 +538,14 @@ export default function ActiveSession() {
         (foundItem as any)?.content?.ingredients ??
         (foundItem as any)?.contents?.ingredients ??
         (foundItem as any)?.ingredients ??
-        localContent?.ingredients ??
         [];
 
       const parsedIngredients = normalizeIngredients(robustIngredients);
       const activityType = inferSessionActivityType({
         foundItem,
         relatedScenario,
-        contentCategory: contentData?.category ?? localContent?.category,
-        contentType: contentData?.type ?? localContent?.type,
+        contentCategory: contentData?.category,
+        contentType: contentData?.type,
       });
       const configuredDevices = resolveConfiguredDevices(
         getItemDevices(foundItem),

--- a/app/activity-details.tsx
+++ b/app/activity-details.tsx
@@ -24,7 +24,6 @@ import { CustomAlert } from '@/components/CustomAlert';
 import {
   Activity,
   Content,
-  CONTENTS,
   Scenario,
   ScenarioDeviceState,
 } from '@/constants/data';
@@ -165,6 +164,11 @@ const getItemDevices = (item: Activity | Scenario) =>
   ('devices' in item && Array.isArray(item.devices)
     ? item.devices
     : []) as ScenarioDeviceState[];
+
+const getReadableDeviceName = (config: ScenarioDeviceState) =>
+  config.deviceName ||
+  SMART_HOME_DEVICES[config.deviceId]?.name ||
+  getScenarioDeviceMeta(config).name;
 
 const resolveConfiguredDevices = (
   activityDevices: ScenarioDeviceState[],
@@ -330,7 +334,6 @@ export default function ActivityDetails() {
 
         const contentPromise = foundActivity.content_id
           ? (async () => {
-              const localContent = CONTENTS[String(foundActivity.content_id)];
               const { data: contentRows, error: contentError } = await supabase
                 .from('contents')
                 .select('*')
@@ -345,23 +348,19 @@ export default function ActivityDetails() {
                   title: contentData.title,
                   type: contentData.type,
                   category: contentData.category,
-                  genre: contentData.genre || localContent?.genre,
+                  genre: contentData.genre || undefined,
                   description: contentData.description,
                   duration: contentData.duration,
-                  image: resolveCatalogImage(
-                    contentData.image || localContent?.image,
-                  ),
-                  instructions:
-                    contentData.instructions || localContent?.instructions,
-                  ingredients:
-                    contentData.ingredients || localContent?.ingredients,
-                  videoUrl: localContent?.videoUrl || contentData.video_url,
-                  mediaUrl: localContent?.mediaUrl || contentData.media_url || contentData.video_url,
-                  author: contentData.author || localContent?.author,
+                  image: resolveCatalogImage(contentData.image),
+                  instructions: contentData.instructions,
+                  ingredients: contentData.ingredients,
+                  videoUrl: contentData.video_url || undefined,
+                  mediaUrl: contentData.media_url || contentData.video_url || undefined,
+                  author: contentData.author || undefined,
                 } as Content;
               }
 
-              return localContent || null;
+              return null;
             })()
           : Promise.resolve(null);
 
@@ -424,11 +423,6 @@ export default function ActivityDetails() {
     };
     loadData();
   }, [id]);
-
-  const displayDescription =
-    !isActivity && relatedScenario?.description
-      ? relatedScenario.description
-      : mainItem?.description;
 
   const handleCustomBack = () => {
     if (isNew === 'true') {
@@ -744,6 +738,47 @@ export default function ActivityDetails() {
     Array.isArray(relatedScenario?.devices) ? relatedScenario.devices : [],
   );
 
+  const deviceNames = Array.from(
+    new Set(
+      devicesToShow
+        .map((config) => getReadableDeviceName(config).trim())
+        .filter(Boolean),
+    ),
+  );
+
+  const scenarioDescription =
+    relatedScenario?.description?.trim() || '';
+  const baseDescription =
+    (!isActivity && scenarioDescription) ||
+    mainItem?.description?.trim() ||
+    scenarioDescription;
+  const mergedDescription = (() => {
+    const descriptionParts = [baseDescription];
+
+    if (
+      isActivity &&
+      scenarioDescription &&
+      scenarioDescription !== baseDescription &&
+      !scenarioDescription.startsWith(baseDescription)
+    ) {
+      descriptionParts.push(scenarioDescription);
+    } else if (
+      isActivity &&
+      scenarioDescription.startsWith(baseDescription) &&
+      scenarioDescription.length > baseDescription.length
+    ) {
+      descriptionParts[0] = scenarioDescription;
+    }
+
+    if (deviceNames.length > 0) {
+      descriptionParts.push(
+        `Devices involved: ${deviceNames.join(', ')}.`,
+      );
+    }
+
+    return descriptionParts.filter(Boolean).join('\n\n');
+  })();
+
   const activeSpeakerConfig = devicesToShow.find((config) => {
     const device = SMART_HOME_DEVICES[config.deviceId];
     const fallbackMeta = getScenarioDeviceMeta(config);
@@ -836,7 +871,7 @@ export default function ActivityDetails() {
               className="text-[#586963] text-[16px] leading-6"
               style={{ fontFamily: 'Nunito_400Regular' }}
             >
-              {displayDescription}
+              {mergedDescription}
             </Text>
           </View>
 

--- a/app/activity-details.tsx
+++ b/app/activity-details.tsx
@@ -677,24 +677,75 @@ export default function ActivityDetails() {
   };
 
   const handleDeleteActivity = () => {
+    const deletingScenario = !isActivity;
     setAlertConfig({
       visible: true,
-      title: 'Delete Activity',
+      title: deletingScenario ? 'Delete Scenario' : 'Delete Activity',
       message:
-        'Are you sure you want to delete this activity? This action cannot be undone.',
+        deletingScenario
+          ? 'Are you sure you want to delete this scenario? This action cannot be undone.'
+          : 'Are you sure you want to delete this activity? This action cannot be undone.',
       confirmText: 'Delete',
       cancelText: 'Cancel',
       isDestructive: true,
       onConfirm: async () => {
         try {
-          // Deletar a atividade na nuvem do Supabase
-          apiLog('DELETE', 'activities', { id });
-          const { error } = await supabase
-            .from('activities')
-            .delete()
-            .eq('id', id);
+          if (deletingScenario) {
+            const scenarioDbId = parseUserScenarioDbId(id);
 
-          if (error) throw error;
+            const [{ count: linkedActivitiesCount, error: linkedActivitiesError }, { count: linkedRoutinesCount, error: linkedRoutinesError }] = await Promise.all([
+              supabase
+                .from('activities')
+                .select('id', { count: 'exact', head: true })
+                .eq('scenario_id', scenarioDbId),
+              supabase
+                .from('routines')
+                .select('id', { count: 'exact', head: true })
+                .eq('scenario_id', scenarioDbId),
+            ]);
+
+            if (linkedActivitiesError) throw linkedActivitiesError;
+            if (linkedRoutinesError) throw linkedRoutinesError;
+
+            const blockingRefs = (linkedActivitiesCount ?? 0) + (linkedRoutinesCount ?? 0);
+            if (blockingRefs > 0) {
+              setAlertConfig({
+                visible: true,
+                title: 'Scenario in use',
+                message:
+                  'This scenario is linked to existing activities or routines. Remove those links first, then try deleting the scenario again.',
+                confirmText: 'OK',
+                cancelText: '',
+                isDestructive: false,
+                onConfirm: undefined,
+                onCancel: undefined,
+              });
+              return;
+            }
+
+            apiLog('DELETE', 'scenarios', { id: scenarioDbId });
+            const { error: shortcutDeleteError } = await supabase
+              .from('shortcuts')
+              .delete()
+              .eq('scenario_idscenario', scenarioDbId);
+
+            if (shortcutDeleteError) throw shortcutDeleteError;
+
+            const { error } = await supabase
+              .from('scenarios')
+              .delete()
+              .eq('id', scenarioDbId);
+
+            if (error) throw error;
+          } else {
+            apiLog('DELETE', 'activities', { id });
+            const { error } = await supabase
+              .from('activities')
+              .delete()
+              .eq('id', id);
+
+            if (error) throw error;
+          }
 
           router.navigate('/Activities');
         } catch (e) {

--- a/app/new-activity.tsx
+++ b/app/new-activity.tsx
@@ -1,4 +1,4 @@
-import { Content, CONTENTS } from '@/constants/data';
+import { Content } from '@/constants/data';
 import { resolveCatalogImage } from '@/constants/data/catalogAssets';
 import { Activity, Scenario } from '@/constants/data/types';
 import {
@@ -12,7 +12,6 @@ import { apiLog, supabase, uploadImage } from '../utils/supabase';
 
 import { useNotifications } from '@/context/NotificationsContext';
 import {
-  fetchScenarioTemplates,
   fetchUserScenarios,
   parseUserScenarioDbId,
 } from '@/utils/catalogTemplates';
@@ -350,24 +349,18 @@ export default function NewActivityFlow() {
       if (data && !error) {
         setDbContent(
           (data as ContentRow[]).map((c) => {
-            const localContent = CONTENTS[c.id as keyof typeof CONTENTS];
-
             return {
               id: c.id,
-              title: c.title || localContent?.title,
-              type: c.type || localContent?.type,
-              category: c.category || localContent?.category,
-              description: c.description || localContent?.description,
-              duration: c.duration || localContent?.duration,
-              image: resolveCatalogImage(c.image || localContent?.image),
-              instructions:
-                normalizeContentInstructions(c.instructions) ||
-                localContent?.instructions,
-              ingredients:
-                normalizeContentIngredients(c.ingredients) ||
-                localContent?.ingredients,
-              videoUrl: localContent?.videoUrl || c.video_url || undefined,
-              author: c.author || localContent?.author,
+              title: c.title,
+              type: c.type,
+              category: c.category,
+              description: c.description,
+              duration: c.duration,
+              image: resolveCatalogImage(c.image),
+              instructions: normalizeContentInstructions(c.instructions),
+              ingredients: normalizeContentIngredients(c.ingredients),
+              videoUrl: c.video_url || undefined,
+              author: c.author || undefined,
             };
           }),
         );
@@ -438,13 +431,8 @@ export default function NewActivityFlow() {
   useEffect(() => {
     const fetchScenarios = async () => {
       try {
-        const [templateScenarios, userScenarios] = await Promise.all([
-          fetchScenarioTemplates(),
-          fetchUserScenarios().catch(() => []),
-        ]);
-
-        const mergedScenarios = [...userScenarios, ...templateScenarios];
-        const uniqueScenarios = mergedScenarios.filter(
+        const userScenarios = await fetchUserScenarios().catch(() => []);
+        const uniqueScenarios = userScenarios.filter(
           (scenario, index, list) =>
             list.findIndex((item) => item.id === scenario.id) === index,
         );
@@ -526,13 +514,7 @@ export default function NewActivityFlow() {
   }, [room_id, homeRooms]);
 
   const allContent = useMemo(() => {
-    const combined = [...dbContent];
-    Object.values(CONTENTS).forEach((local: Content) => {
-      if (!combined.find((db: Content) => db.id === local.id)) {
-        combined.push(local);
-      }
-    });
-    return combined;
+    return dbContent;
   }, [dbContent]);
 
   useEffect(() => {

--- a/components/activitiesScenarios/UnifiedCard.tsx
+++ b/components/activitiesScenarios/UnifiedCard.tsx
@@ -1,6 +1,5 @@
 import { MaterialCommunityIcons, MaterialIcons } from '@expo/vector-icons';
 import MaskedView from '@react-native-masked-view/masked-view';
-import { Image as ExpoImage } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import React from 'react';
 import {
@@ -51,15 +50,15 @@ export const UnifiedCard = ({
       accessibilityLabel={`${title}. ${time ? `Duration: ${time}.` : ''} ${room ? `Room: ${room}.` : ''}`}
       accessibilityHint={`Press to go to the details of ${title}`}
     >
-      <View style={StyleSheet.absoluteFill}>
+      <View style={[StyleSheet.absoluteFill, { transform: [{ scale: 1.5 }] }]}>
         <Image
           source={imageSource}
-          style={[StyleSheet.absoluteFill, { transform: [{ scale: 1.45 }] }]}
+          style={StyleSheet.absoluteFill}
           resizeMode="cover"
-          blurRadius={85}
+          blurRadius={90}
           accessible={false}
+          importantForAccessibility="no"
         />
-        <View className="absolute inset-0 " />
       </View>
 
       <MaskedView
@@ -67,23 +66,24 @@ export const UnifiedCard = ({
         maskElement={
           <LinearGradient
             colors={['black', 'black', 'transparent']}
-            locations={[0, 0.1, 0.6]}
+            locations={[0, 0.2, 0.75]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 0, y: 1 }}
             style={StyleSheet.absoluteFill}
           />
         }
       >
-        <ExpoImage
+        <Image
           source={imageSource}
           style={StyleSheet.absoluteFill}
-          contentFit="cover"
-          cachePolicy="memory-disk"
-          transition={200}
+          resizeMode="cover"
+          accessible={false}
+          importantForAccessibility="no"
         />
       </MaskedView>
 
       <LinearGradient
-        colors={['transparent', 'rgba(0,0,0,0.3)', 'rgba(0,0,0,0.5)']}
-        locations={[0.4, 0.7, 1]}
+        colors={['rgba(0,0,0,0.1)', 'rgba(0,0,0,0.3)', 'rgba(0,0,0,0.6)']}
         style={StyleSheet.absoluteFill}
         pointerEvents="none"
       />

--- a/supabase/migrations/20260620183000_remove_static_catalog_templates.sql
+++ b/supabase/migrations/20260620183000_remove_static_catalog_templates.sql
@@ -1,0 +1,3 @@
+delete from public.activity_templates;
+
+delete from public.scenario_templates;

--- a/supabase/tests/database/schema_smoke_test.sql
+++ b/supabase/tests/database/schema_smoke_test.sql
@@ -35,8 +35,8 @@ SELECT ok(
   'scenario_templates has RLS enabled'
 );
 
-SELECT is((SELECT count(*)::int FROM public.activity_templates), 14, 'activity templates are seeded');
-SELECT is((SELECT count(*)::int FROM public.scenario_templates), 13, 'scenario templates are seeded');
+SELECT is((SELECT count(*)::int FROM public.activity_templates), 0, 'activity templates are empty after static catalog cleanup');
+SELECT is((SELECT count(*)::int FROM public.scenario_templates), 0, 'scenario templates are empty after static catalog cleanup');
 SELECT ok(
   EXISTS (
     SELECT 1

--- a/utils/aiActivities.ts
+++ b/utils/aiActivities.ts
@@ -193,8 +193,26 @@ export const isAiRateLimitError = async (error: unknown) => {
 };
 
 export const getNidushAiErrorMessage = async (error: unknown) => {
+  const message = await getFunctionErrorMessage(error);
+  const normalized = normalizeErrorText(message);
+
   if (await isAiRateLimitError(error)) {
     return 'Our AI guide is taking a short pause right now. Try again in about an hour.';
+  }
+
+  if (
+    normalized.includes('no home connected to this user') ||
+    normalized.includes('no home connected')
+  ) {
+    return 'Connect your profile to a home before saving AI activities.';
+  }
+
+  if (normalized.includes('invalid session') || normalized.includes('missing authorization header')) {
+    return 'Your session expired. Please sign in again and try once more.';
+  }
+
+  if (normalized.includes('row-level security') || normalized.includes('permission')) {
+    return 'This AI activity could not be saved because the database rejected the request. Check the latest Supabase policies and try again.';
   }
 
   return 'We could not create an AI suggestion right now. Please try again in a little while.';

--- a/utils/catalogTemplates.ts
+++ b/utils/catalogTemplates.ts
@@ -73,36 +73,6 @@ let scenarioTemplatesPromise: Promise<Scenario[]> | null = null;
 
 export const USER_SCENARIO_ID_PREFIX = 'scenario:';
 
-const LOCAL_SCENARIO_TEMPLATES: Scenario[] = [
-  {
-    id: 's900',
-    title: 'TV Relaxation',
-    description:
-      'A living room wind-down scene that uses the TV as the main ambient device.',
-    room: 'Living Room',
-    room_id: 'Living Room',
-    image: resolveCatalogImage('Scenarios/moonlight_bay.png'),
-    category: 'My creations',
-    devices: [
-      {
-        deviceId: 'dev_tv_living',
-        state: 'on',
-        value: 'Ocean visuals',
-      },
-      {
-        deviceId: 'dev_speaker_living',
-        state: 'on',
-        value: 'Calm music',
-      },
-    ],
-    playlist: 'Peaceful Meditation',
-    playlist_id: '37i9dQZF1DWZ0XmS6AnY9s',
-    focusMode: true,
-    shortcuts: false,
-    keywords: ['tv', 'relax', 'meditation', 'living room'],
-  },
-];
-
 const normalizeActivityType = (type: string | null | undefined): Activity['type'] => {
   const normalized = String(type ?? 'other').toLowerCase();
   if (normalized === 'audiobook') return 'audiobooks';
@@ -150,200 +120,6 @@ export const resolvePossibleUserScenarioDbIds = (value: unknown) => {
 const normalizeActivityTemplateId = (id: string) =>
   id.startsWith('template:') ? id.replace(/^template:/, '') : id;
 
-const LOCAL_ACTIVITY_TEMPLATE_ROWS: ActivityTemplateRow[] = [
-  {
-    id: '1',
-    title: 'Italian Night',
-    description: 'A cozy cooking session with italian vibes.',
-    room: 'Kitchen',
-    image: 'cooking_activities/my_creations_cooking/italian_night.png',
-    category: 'My creations',
-    type: 'cooking',
-    content_id: 'c1',
-    scenario_id: 's4',
-    shortcuts: false,
-    keywords: ['evening', 'dinner', 'italian', 'pasta', 'relaxed'],
-  },
-  {
-    id: '2',
-    title: 'Sunrise Flow',
-    description: 'Start your day with energy.',
-    room: 'Living Room',
-    image: 'activities_for_you/sunrise_flow.png',
-    category: 'My creations',
-    type: 'meditation',
-    content_id: 'c9',
-    scenario_id: 's1',
-    shortcuts: false,
-    keywords: ['morning', 'energy', 'meditation', 'stressed'],
-  },
-  {
-    id: '3',
-    title: 'Gratitude Flow',
-    description:
-      'With a gentle voice guiding you, focus for 8 minutes on things you are grateful for.',
-    room: 'Bedroom',
-    image: 'meditation_activities/my_creations/gratitude_flow.png',
-    category: 'My creations',
-    type: 'meditation',
-    content_id: 'c2',
-    scenario_id: 's5',
-    shortcuts: false,
-    keywords: ['morning', 'gratitude', 'zen', 'relaxed'],
-  },
-  {
-    id: '4',
-    title: 'Brownies',
-    description: 'Easy homemade brownies that are fudgy and delicious.',
-    room: 'Kitchen',
-    image: 'cooking_activities/recommended/brownies.png',
-    category: null,
-    type: 'cooking',
-    content_id: 'c3',
-    scenario_id: 's3',
-    shortcuts: false,
-    keywords: ['chocolate', 'dessert', 'baking', 'relaxed'],
-  },
-  {
-    id: '5',
-    title: 'Morning Zen',
-    description: 'Quick meditation session.',
-    room: 'Living Room',
-    image: 'meditation_content/video_sessions/morning_zen.png',
-    category: null,
-    type: 'meditation',
-    content_id: 'c2',
-    scenario_id: 's5',
-    shortcuts: false,
-    keywords: ['morning', 'zen', 'meditation', 'stressed'],
-  },
-  {
-    id: '6',
-    title: 'Eggs Benedict',
-    description:
-      'Master the art of the perfect brunch with crispy muffins, tender poached eggs, and rich Hollandaise sauce.',
-    room: 'Kitchen',
-    image: 'cooking_activities/recommended/eggs_benedict.png',
-    category: null,
-    type: 'cooking',
-    content_id: 'c10',
-    scenario_id: 's4',
-    shortcuts: false,
-    keywords: ['morning', 'breakfast', 'brunch', 'relaxed'],
-  },
-  {
-    id: '7',
-    title: 'Vodka Pasta',
-    description:
-      'A rich and creamy tomato sauce infused with a splash of vodka.',
-    room: 'Kitchen',
-    image: 'cooking_activities/simple_recipes/vodka_pasta.png',
-    category: 'Simple recipes',
-    type: 'cooking',
-    content_id: 'c14',
-    scenario_id: null,
-    shortcuts: false,
-    keywords: ['evening', 'dinner', 'pasta', 'cooking'],
-  },
-  {
-    id: '8',
-    title: 'Evening Read',
-    description:
-      'Unwind after a long day with an engaging audiobook summary.',
-    room: 'Bedroom',
-    image: 'activities_for_you/evening_read.png',
-    category: null,
-    type: 'audiobooks',
-    content_id: 'c8',
-    scenario_id: 's2',
-    shortcuts: false,
-    keywords: ['evening', 'reading', 'relax', 'focus'],
-  },
-  {
-    id: '9',
-    title: 'Chocolate Cake',
-    description:
-      'A rich, moist, and decadent chocolate cake for a special celebration.',
-    room: 'Kitchen',
-    image: 'cooking_activities/simple_recipes/chocolate_cake.png',
-    category: 'Simple recipes',
-    type: 'cooking',
-    content_id: 'c13',
-    scenario_id: null,
-    shortcuts: false,
-    keywords: ['dessert', 'chocolate', 'baking', 'relaxed'],
-  },
-  {
-    id: '10',
-    title: 'Pasta Primo',
-    description:
-      'A simple pasta dish for a quick lunch or hassle-free weeknight dinner.',
-    room: 'Kitchen',
-    image: 'cooking_activities/simple_recipes/pasta.png',
-    category: 'Simple recipes',
-    type: 'cooking',
-    content_id: 'c12',
-    scenario_id: null,
-    shortcuts: false,
-    keywords: ['lunch', 'dinner', 'quick', 'pasta'],
-  },
-  {
-    id: '11',
-    title: 'Stretching',
-    description:
-      'Release tension and improve flexibility with this gentle full-body routine.',
-    room: 'Bedroom',
-    image: 'activities_for_you/stretching.png',
-    category: 'My creations',
-    type: 'workout',
-    content_id: 'c11',
-    scenario_id: 's6',
-    shortcuts: false,
-    keywords: ['morning', 'stretch', 'relax', 'anxious'],
-  },
-  {
-    id: '15',
-    title: 'Visualization for Success',
-    description:
-      'Boost your confidence and clarity by mentally rehearsing your goals.',
-    room: 'Bedroom',
-    image: 'meditation_activities/recommended/visualization_for_success.png',
-    category: 'Meditation',
-    type: 'meditation',
-    content_id: 'c15',
-    scenario_id: 's2',
-    shortcuts: false,
-    keywords: ['focus', 'success', 'confidence', 'anxious'],
-  },
-  {
-    id: '16',
-    title: 'Cooking Time',
-    description:
-      'Transform your kitchen into a culinary studio and create something delicious from scratch.',
-    room: 'Kitchen',
-    image: 'shortcuts/cooking_time.png',
-    category: 'My creations',
-    type: 'cooking',
-    content_id: 'c16',
-    scenario_id: 's12',
-    shortcuts: true,
-    keywords: ['cooking', 'kitchen', 'creative', 'focus'],
-  },
-  {
-    id: '17',
-    title: 'Meditation Time',
-    description:
-      'Dedicate time to stillness and reconnect with your inner peace through guided breathwork.',
-    room: 'Bedroom',
-    image: 'shortcuts/meditation_time.png',
-    category: 'Meditation',
-    type: 'meditation',
-    content_id: 'c17',
-    scenario_id: 's13',
-    shortcuts: true,
-    keywords: ['meditation', 'calm', 'breathing', 'stressed'],
-  },
-];
 
 export const mapActivityTemplate = (row: ActivityTemplateRow): Activity => ({
   id: `template:${row.id}`,
@@ -361,8 +137,6 @@ export const mapActivityTemplate = (row: ActivityTemplateRow): Activity => ({
   shortcuts: row.shortcuts === true,
   keywords: row.keywords ?? [],
 });
-
-const LOCAL_ACTIVITY_TEMPLATES = LOCAL_ACTIVITY_TEMPLATE_ROWS.map(mapActivityTemplate);
 
 export const mapScenarioTemplate = (row: ScenarioTemplateRow): Scenario => ({
   id: row.id,
@@ -433,22 +207,9 @@ export const fetchActivityTemplates = async ({ forceRefresh = false }: FetchCata
       .select('*')
       .order('sort_order', { ascending: true });
 
-    if (error) {
-      console.warn('Falling back to local activity templates:', error);
-      activityTemplatesCache = LOCAL_ACTIVITY_TEMPLATES;
-      return LOCAL_ACTIVITY_TEMPLATES;
-    }
+    if (error) throw error;
 
-    const remoteTemplates = (data ?? []).map(mapActivityTemplate);
-    const remoteIds = new Set(
-      remoteTemplates.map((activity) => normalizeActivityTemplateId(activity.id)),
-    );
-    const templates = [
-      ...remoteTemplates,
-      ...LOCAL_ACTIVITY_TEMPLATES.filter(
-        (activity) => !remoteIds.has(normalizeActivityTemplateId(activity.id)),
-      ),
-    ];
+    const templates = (data ?? []).map(mapActivityTemplate);
     activityTemplatesCache = templates;
     return templates;
   })();
@@ -474,12 +235,7 @@ export const fetchScenarioTemplates = async ({ forceRefresh = false }: FetchCata
       .order('sort_order', { ascending: true });
 
     if (error) throw error;
-    const remoteTemplates = (data ?? []).map(mapScenarioTemplate);
-    const remoteIds = new Set(remoteTemplates.map((scenario) => scenario.id));
-    const templates = [
-      ...remoteTemplates,
-      ...LOCAL_SCENARIO_TEMPLATES.filter((scenario) => !remoteIds.has(scenario.id)),
-    ];
+    const templates = (data ?? []).map(mapScenarioTemplate);
     scenarioTemplatesCache = templates;
     return templates;
   })();
@@ -510,10 +266,6 @@ export const fetchActivityTemplateById = async (id: string) => {
   const cachedTemplate = activityTemplatesCache?.find((item) => normalizeActivityTemplateId(item.id) === templateId);
   if (cachedTemplate) return cachedTemplate;
 
-  const localTemplate = LOCAL_ACTIVITY_TEMPLATES.find(
-    (item) => normalizeActivityTemplateId(item.id) === templateId,
-  );
-
   const { data, error } = await supabase
     .from('activity_templates')
     .select('*')
@@ -521,10 +273,10 @@ export const fetchActivityTemplateById = async (id: string) => {
     .maybeSingle();
 
   if (error) {
-    console.warn('Falling back to local activity template:', error);
-    return localTemplate ?? null;
+    console.warn('Failed to load activity template by id:', error);
+    return null;
   }
-  return data ? mapActivityTemplate(data) : localTemplate ?? null;
+  return data ? mapActivityTemplate(data) : null;
 };
 
 export const fetchScenarioTemplateById = async (id: string) => {
@@ -544,15 +296,15 @@ export const fetchScenarioTemplateById = async (id: string) => {
   const cachedScenario = scenarioTemplatesCache?.find((item) => item.id === normalizedId);
   if (cachedScenario) return cachedScenario;
 
-  const localScenario = LOCAL_SCENARIO_TEMPLATES.find((item) => item.id === normalizedId);
-  if (localScenario) return localScenario;
-
   const { data, error } = await supabase
     .from('scenario_templates')
     .select('*')
     .eq('id', normalizedId)
     .maybeSingle();
 
-  if (error) throw error;
+  if (error) {
+    console.warn('Failed to load scenario template by id:', error);
+    return null;
+  }
   return data ? mapScenarioTemplate(data) : null;
 };


### PR DESCRIPTION

## Summary

This PR removes legacy static activity and scenario recommendations that no longer match the real user home setup, connected devices, or Spotify playlists.

The app now favors:
- real user-created activities
- real user-created scenarios
- AI-generated suggestions when available
- live content data from Supabase instead of local static fallbacks

## What changed

- Removed legacy static catalog fallbacks from activity and scenario flows
- Stopped showing static activity templates in Home recommendations
- Stopped showing static recommended scenarios in the activity creation flow
- Limited scenario selection in new activity creation to real user scenarios
- Removed local static content fallbacks from activity details, active session, and new activity flow
- Improved AI save error handling to show clearer messages in the app
- Improved activity detail descriptions to better reflect linked devices/scenario context
- Adjusted activity/scenario card image treatment while keeping the original card format
- Added a Supabase migration to remove seeded static catalog template data
- Updated the database smoke test to match the new expected empty template tables

## Supabase

This PR includes a migration that clears:
- `public.activity_templates`
- `public.scenario_templates`

After deploying, recommendations should no longer suggest static templates that do not match the user’s real devices or playlists.

## Why

Previously, the app could still recommend activities or scenarios based on old static template data, even when:
- the user did not have the required devices
- the user had no matching Spotify playlists
- the content did not reflect the real home configuration

This PR makes recommendations more honest and aligned with the actual Nidush experience.

## Validation

- `npx tsc --noEmit`
- Updated database smoke test expectations for template cleanup

## Notes

After merging, run:

```bash
supabase db push